### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Strategic-Automation/dspy-compounding-engineering/security/code-scanning/1](https://github.com/Strategic-Automation/dspy-compounding-engineering/security/code-scanning/1)

To fix the problem, explicitly set a `permissions:` block at the top of the workflow to restrict the GitHub Actions GITHUB_TOKEN to only those permissions required by the workflow. As a starting point (unless a particular step requires more), set:
```yaml
permissions:
  contents: read
```
This should be added after the workflow name and before the `on:` block (so it applies to all jobs). If later inspection of all dependent Actions reveals a need for additional permissions (e.g., `pull-requests: write`), more can be added, but for this workflow, read access appears sufficient.

- Edit the file `.github/workflows/test.yml`
- Insert the following block after the `name:` line and before the `on:` line:  
  ```
  permissions:
    contents: read
  ```
- No additional libraries or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
