### PR TITLE
Fix for Empty except

### DIFF
--- a/workflows/plan.py
+++ b/workflows/plan.py
@@ -98,8 +98,9 @@ def _get_relevant_file_contents(max_chars: int = 10000) -> str:
                         file_content = file_content[:max_per_file] + "\n...[truncated]..."
                     content_parts.append(f"--- {filename} ---\n{file_content}")
                     total_chars += len(file_content)
-            except Exception:
-                pass
+            except Exception as e:
+                # Intentionally skip unreadable files, but log for debugging.
+                console.log(f"[yellow]Warning:[/yellow] Failed to read {filename}: {e}")
 
     return "\n\n".join(content_parts) if content_parts else "No key files found."
 


### PR DESCRIPTION
To fix the problem, the `except Exception:` block should not be completely empty. We should either narrow the exception type and/or add handling such as logging the failure, or clearly document why the exception is intentionally ignored. The best fix that preserves existing functionality is to log a concise message to `console` when a file cannot be read, then continue, maintaining the current behavior of skipping problematic files.

Concretely, in `workflows/plan.py` within `_get_relevant_file_contents`, replace the bare `except Exception: pass` with an `except Exception as e:` block that logs a warning using the already‑defined `console` (from `rich.console`). That avoids adding new imports and keeps changes local. For example, print the filename and a brief reason using `console.log` or `console.print`, but do not re‑raise so we still ignore the error and move on.

Only one region in `workflows/plan.py` needs editing: the `except` block around lines 101–102. No new methods or definitions are required and no new external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._