### PR TITLE
Fix for Empty except

### DIFF
--- a/utils/context/project.py
+++ b/utils/context/project.py
@@ -54,8 +54,9 @@ class ProjectContext:
             context_parts.append(
                 f"Project files: {', '.join(f for f in files if not f.startswith('.'))}"
             )
-        except Exception:
-            pass
+        except Exception as e:
+            # Best-effort: if we cannot list project files, continue without failing.
+            console.log(f"Warning: unable to list project files in {self.base_dir!r}: {e}")
 
         key_files = ["README.md", "pyproject.toml", "package.json", "requirements.txt"]
         for kf in key_files:


### PR DESCRIPTION
In general, to fix this problem you either (1) add a clear explanatory comment justifying why exceptions are intentionally ignored, or (2) replace the empty `except` body with minimal handling, such as logging the error at debug level while still allowing execution to continue. Both approaches make the intent explicit and avoid completely silent failure.

The best way here without changing existing functionality is to keep the non-fatal behavior (do not re-raise, do not change return values), but add a brief comment and log the exception at a low-verbosity level. That way, normal behavior of `get_context` is preserved, but developers can inspect logs to understand why project files weren’t listed. Since `rich.console.Console` is already instantiated as `console`, we can use `console.log` for this purpose and we don’t need new imports.

Concretely, in `utils/context/project.py`, in `ProjectContext.get_context`, replace the `except Exception: pass` block (lines 57–58) with an `except Exception as e:` that includes a short explanatory comment and a `console.log` call. No other lines in this file need changes, and no additional methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._