### PR TITLE
🎨 Palette: Add actionable next steps to empty states

### DIFF
--- a/workflows/sync.py
+++ b/workflows/sync.py
@@ -252,6 +252,11 @@ def run_sync(
 
     if not syncable_files:
         console.print("[dim]No pending or ready todos found to sync.[/dim]")
+        console.print(
+            "[dim]Use [cyan]compounding review[/cyan] to analyze your code and "
+            "generate new findings,\n"
+            "or [cyan]compounding plan[/cyan] to create a new feature plan.[/dim]\n"
+        )
         return results
 
     console.print(f"[bold]Found {len(syncable_files)} todos to sync.[/bold]\n")

--- a/workflows/work.py
+++ b/workflows/work.py
@@ -109,6 +109,10 @@ def _run_react_todo(  # noqa: C901
 
     if not todos:
         console.print("[yellow]No ready todos found matching the criteria.[/yellow]")
+        console.print(
+            "[dim]Use [cyan]compounding triage[/cyan] to approve pending todos "
+            "or [cyan]compounding review[/cyan] to generate new ones.[/dim]\n"
+        )
         return
 
     console.print(f"[green]Found {len(todos)} ready todos.[/green]")


### PR DESCRIPTION
Added helpful messages indicating the next actions users can take when no todos are found during `compounding work` and `compounding sync` commands. This avoids dead-ends and improves the usability of the CLI tool.

---
*PR created automatically by Jules for task [8983449361466696566](https://jules.google.com/task/8983449361466696566) started by @Dan-StrategicAutomation*