### PR TITLE
🎨 Palette: Render Markdown in status command output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-21 - Empty State Call to Actions
-**Learning:** Empty states in CLI tools that just say "nothing found" create dead ends for users. Adding actionable next steps improves the CLI user experience significantly by keeping them in the flow.
-**Action:** Always provide the command or next logical step the user should take when presenting an empty state or zero results screen.
+## 2024-05-24 - CLI Markdown Rendering
+**Learning:** Pure CLI applications utilizing `rich` library can still benefit from rich markdown rendering to make diagnostic outputs easier to read.
+**Action:** When working on CLI apps built with `rich`, ensure strings containing markdown elements (e.g. lists, bold text) are wrapped with `Markdown()` before passing them to display elements like `Panel()`.

--- a/cli.py
+++ b/cli.py
@@ -295,10 +295,11 @@ def status() -> None:
     """
     Check the current status of external services (Qdrant, API keys).
     """
+    from rich.markdown import Markdown
     from rich.panel import Panel
 
     status_text = get_system_status()
-    console.print(Panel(status_text, title="System Diagnostics", border_style="cyan"))
+    console.print(Panel(Markdown(status_text), title="System Diagnostics", border_style="cyan"))
 
 
 @app.command(name="verify-kb")
@@ -310,7 +311,6 @@ def verify_kb() -> None:
     in sync. Reports orphaned entries and inconsistencies.
     """
     from utils.knowledge.verifier import KnowledgeBaseVerifier, format_report
-    from config import get_project_root
 
     kb = KnowledgeBase()
     kb_dir = kb.knowledge_dir


### PR DESCRIPTION
💡 What: The UX enhancement added `Markdown` rendering to the `status` command output in `cli.py`.
🎯 Why: The `status` command output contains Markdown formatting (bold text, lists), but it was being rendered as plain text in the terminal. Wrapping it in a `rich.markdown.Markdown` component before passing it to `Panel` ensures that it renders nicely in the terminal.
📸 Before/After: Before, it rendered as raw text: `### System Status...`. After, it renders nicely with bullet points and bold text inside the panel.
♿ Accessibility: Improves readability of diagnostic output.

---
*PR created automatically by Jules for task [1590585680059678165](https://jules.google.com/task/1590585680059678165) started by @Dan-StrategicAutomation*