### PR TITLE
🎨 Palette: Use `logger.status` for rich console spinners

### DIFF
--- a/utils/knowledge/indexer.py
+++ b/utils/knowledge/indexer.py
@@ -211,7 +211,7 @@ class CodebaseIndexer(CollectionManagerMixin):
         updated_count = 0
         skipped_count = 0
 
-        with console.status(f"Indexing {len(files)} files...") as status:
+        with logger.status(f"Indexing {len(files)} files...") as status:
             for filepath in files:
                 if self._should_ignore(filepath):
                     continue

--- a/utils/knowledge/verifier.py
+++ b/utils/knowledge/verifier.py
@@ -244,7 +244,7 @@ class KnowledgeBaseVerifier:
                 findings.append(VerificationFinding(
                     severity="warning",
                     category="orphan",
-                    message=f"Orphaned DB entry (no JSON file)",
+                    message="Orphaned DB entry (no JSON file)",
                     details=f"Learning ID: {oid}",
                 ))
 

--- a/utils/mcp/client.py
+++ b/utils/mcp/client.py
@@ -1,14 +1,12 @@
 import asyncio
-import inspect
-import sys
 import threading
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import dspy
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
 
 from config import settings
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
 from utils.io.logger import logger
 
 
@@ -34,7 +32,7 @@ class MCPManager:
     def _init(self):
         self._servers: Dict[str, dict] = {}
         self._tools: Dict[str, dspy.Tool] = {}
-        
+
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()
@@ -56,26 +54,26 @@ class MCPManager:
                 command=command[0],
                 args=command[1:]
             )
-            
+
             # Since fastmcp stdio runs over stdin/stdout, we must be careful with logging
             # But here we are the client.
             stdio_ctx = stdio_client(server_params)
             read, write = await stdio_ctx.__aenter__()
-            
+
             session = ClientSession(read, write)
             await session.__aenter__()
             await session.initialize()
-            
+
             # Discover tools
             response = await session.list_tools()
-            
+
             self._servers[name] = {
                 "session": session,
                 "stdio_ctx": stdio_ctx,
                 "tools": response.tools
             }
             logger.debug(f"Successfully connected to MCP Server: {name} ({len(response.tools)} tools)")
-            
+
         except Exception as e:
             logger.error(f"Failed to connect to MCP server '{name}': {e}")
             raise
@@ -93,7 +91,7 @@ class MCPManager:
         """
         if tool_name in self._tools:
             return self._tools[tool_name]
-        
+
         for server_name, server_data in self._servers.items():
             for mcp_tool in server_data["tools"]:
                 if mcp_tool.name == tool_name:
@@ -117,19 +115,19 @@ class MCPManager:
         Creates a synchronous Python function that correctly maps arguments
         and calls the MCP tool over the background event loop, then wraps it in dspy.Tool.
         """
-        # Dynamic function generation using exec to preserve signature, 
+        # Dynamic function generation using exec to preserve signature,
         # or simplified *args, **kwargs approach with docstring.
         # DSPy relies heavily on signatures for prompt generation.
-        
+
         def wrapper(*args, **kwargs):
             # For simplicity, we assume named arguments are used or we can map them.
-            # In a robust implementation, we would inspect the mcp_tool schema 
+            # In a robust implementation, we would inspect the mcp_tool schema
             # and map *args to **kwargs cleanly. FastMCP/MCP tools take named arguments.
-            
+
             # Convert args to kwargs if needed (simplified assumption: caller uses kwargs)
             if args:
                 logger.warning(f"MCP tool {mcp_tool.name} was called with positional arguments. This might fail if the names don't match the schema.")
-            
+
             async def _call():
                 session: ClientSession = self._servers[server_name]["session"]
                 result = await session.call_tool(mcp_tool.name, arguments=kwargs)
@@ -146,7 +144,7 @@ class MCPManager:
         # Set metadata for DSPy to read
         wrapper.__name__ = mcp_tool.name
         wrapper.__doc__ = mcp_tool.description or "No description provided."
-        
+
         return dspy.Tool(wrapper)
 
     def close(self):
@@ -158,7 +156,7 @@ class MCPManager:
                     await data["stdio_ctx"].__aexit__(None, None, None)
                 except Exception as e:
                     logger.debug(f"Error closing MCP server {name}: {e}")
-        
+
         self._run_sync(_close())
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=2.0)

--- a/workflows/codify.py
+++ b/workflows/codify.py
@@ -6,13 +6,11 @@ into the persistent knowledge base using the FeedbackCodifier agent.
 """
 
 import dspy
-from rich.console import Console
 from rich.panel import Panel
 
 from agents.workflow.feedback_codifier import FeedbackCodifier
+from utils.io.logger import console, logger
 from utils.knowledge import KnowledgeBase
-
-console = Console()
 
 
 def run_codify(feedback: str, source: str = "manual_input"):
@@ -32,7 +30,7 @@ def run_codify(feedback: str, source: str = "manual_input"):
     existing_knowledge = kb.get_context_string(query=feedback)
 
     # 2. Run FeedbackCodifier Agent
-    with console.status("[cyan]Analyzing and codifying feedback...[/cyan]"):
+    with logger.status("[cyan]Analyzing and codifying feedback...[/cyan]"):
         # Use ChainOfThought for robust typed output
         codifier = dspy.ChainOfThought(FeedbackCodifier)
         result = codifier(

--- a/workflows/generate_agent.py
+++ b/workflows/generate_agent.py
@@ -9,7 +9,6 @@ import os
 from typing import Optional
 
 import dspy
-from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm
 from rich.syntax import Syntax
@@ -17,8 +16,7 @@ from rich.syntax import Syntax
 from agents.workflow.agent_generator import AgentGenerator
 from config import settings
 from utils.agent.tools import get_research_tools
-
-console = Console()
+from utils.io.logger import console, logger
 
 
 def _get_existing_review_agents() -> str:
@@ -176,7 +174,7 @@ def run_generate_agent(description: str, dry_run: bool = False):
     # Phase 1: Gather context
     console.rule("[bold]Phase 1: Context Gathering[/bold]")
 
-    with console.status("[cyan]Analyzing existing review agents...[/cyan]"):
+    with logger.status("[cyan]Analyzing existing review agents...[/cyan]"):
         existing_agents = _get_existing_review_agents()
 
     console.print("[green]✓ Context gathered[/green]")
@@ -185,7 +183,7 @@ def run_generate_agent(description: str, dry_run: bool = False):
     # Phase 2: Generate agent specification
     console.rule("[bold]Phase 2: Agent Generation[/bold]")
 
-    with console.status("[cyan]Generating agent code (with research)...[/cyan]"):
+    with logger.status("[cyan]Generating agent code (with research)...[/cyan]"):
         # Use centralized research tools (web search, docs, codebase, etc.)
         tools = get_research_tools()
 

--- a/workflows/plan.py
+++ b/workflows/plan.py
@@ -1,18 +1,16 @@
 import os
 import re
 
-from rich.console import Console
-
 from agents.research.best_practices_researcher import BestPracticesResearcherModule
 from agents.research.framework_docs_researcher import FrameworkDocsResearcherModule
-from agents.research.repo_research_analyst import RepoResearchAnalystModule
 from agents.research.git_history_analyzer import GitHistoryAnalyzerModule
+from agents.research.repo_research_analyst import RepoResearchAnalystModule
 from agents.workflow.plan_generator import PlanGenerator
 from agents.workflow.spec_flow_analyzer import SpecFlowAnalyzer
 from config import settings
+from utils.io.logger import console, logger
 from utils.knowledge import KBPredict, KnowledgeBase
 
-console = Console()
 
 def _get_safe_name(description: str) -> str:
     """Generate a safe filename from description."""
@@ -59,7 +57,7 @@ def _handle_github_issue(feature_description: str) -> tuple[str, dict]:
             )
 
     if is_issue:
-        with console.status(f"Fetching GitHub issue {feature_description}..."):
+        with logger.status(f"Fetching GitHub issue {feature_description}..."):
             issue_id = feature_description.lstrip("#")
             # If it's a URL, the git service should handle extraction or we do it here
             if "/" in issue_id:
@@ -136,14 +134,14 @@ def run_plan(feature_description: str):
     console.rule("Phase 1: Research")
     kb = KnowledgeBase()
 
-    with console.status("Scanning project structure..."):
+    with logger.status("Scanning project structure..."):
         semantic_results = kb.search_codebase(
             target_description, limit=settings.search_limit_codebase
         )
         if semantic_results:
             console.print(f"[dim]Found {len(semantic_results)} semantic code matches[/dim]")
 
-    with console.status("Running Research Agents..."):
+    with logger.status("Running Research Agents..."):
         repo_research = KBPredict(
             RepoResearchAnalystModule,
             kb_tags=["planning", "repo-research"],
@@ -151,7 +149,7 @@ def run_plan(feature_description: str):
         console.print("[green]✓ Repo Research Complete[/green]")
         repo_md = repo_research.research_report.format_markdown()
         _save_stage_output(plans_dir, safe_name, "1-repo-research", repo_md)
-        
+
         git_history = KBPredict(
             GitHistoryAnalyzerModule,
             kb_tags=["planning", "git-history"],
@@ -204,7 +202,7 @@ def run_plan(feature_description: str):
 
     # 2. SpecFlow Analysis
     console.rule("Phase 2: SpecFlow Analysis")
-    with console.status("Analyzing User Flows..."):
+    with logger.status("Analyzing User Flows..."):
         spec_flow = KBPredict(
             SpecFlowAnalyzer,
             kb_tags=["planning", "spec-flow"],
@@ -214,7 +212,7 @@ def run_plan(feature_description: str):
 
     # 3. Plan Generation
     console.rule("Phase 3: Plan Generation")
-    with console.status("Generating Plan..."):
+    with logger.status("Generating Plan..."):
         planner = KBPredict(
             PlanGenerator,
             kb_tags=["planning", "architecture"],

--- a/workflows/sync.py
+++ b/workflows/sync.py
@@ -10,13 +10,11 @@ import os
 import re
 from typing import Optional
 
-from rich.console import Console
 from rich.table import Table
 
 from utils.github import GitHubService
+from utils.io.logger import console, logger
 from utils.todo import parse_todo, serialize_todo
-
-console = Console()
 
 
 def _extract_title_from_body(body: str) -> str:
@@ -261,7 +259,7 @@ def run_sync(
 
     console.print(f"[bold]Found {len(syncable_files)} todos to sync.[/bold]\n")
 
-    with console.status("Syncing to GitHub..."):
+    with logger.status("Syncing to GitHub..."):
         for file_path in sorted(syncable_files):
             _sync_single_file(file_path, dry_run, available_labels, results)
 

--- a/workflows/triage.py
+++ b/workflows/triage.py
@@ -7,7 +7,7 @@ from rich.prompt import Prompt
 from rich.table import Table
 
 from agents.workflow.triage_agent import TriageAgent
-from utils.io.logger import console
+from utils.io.logger import console, logger
 from utils.knowledge import KBPredict
 from utils.todo import add_work_log_entry, complete_todo
 
@@ -117,7 +117,7 @@ def run_triage():  # noqa: C901
         console.rule(f"[{idx}/{total_items}] Triaging: {filename}")
 
         # Use LLM to present the finding
-        with console.status("Analyzing finding..."):
+        with logger.status("Analyzing finding..."):
             response = triage_predictor(finding_content=content)
 
         console.print(Markdown(response.formatted_presentation))


### PR DESCRIPTION
💡 What: Replaced direct usage of `console.status` from `rich.console` with the `logger.status` wrapper from `utils.io.logger`.
🎯 Why: `logger.status` internally calls `SystemLogger.info` which captures the status message in the persistent file log before showing the rich console spinner. Using `console.status` directly causes these important state changes to not be captured in the file log.
📸 Before/After: Code changes only, no visual change to the end user.
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [7754874190626646345](https://jules.google.com/task/7754874190626646345) started by @Dan-StrategicAutomation*