### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace compile() with ast.parse() for safer syntax validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Use of direct `subprocess.run` calls (e.g., in `workflows/review.py`) instead of the custom `run_safe_command` wrapper (`utils.io.safe`), bypassing the executable allowlist and `shell=True` prevention mechanisms.
 **Learning:** Security wrappers like `run_safe_command` are only effective if used universally. Direct use of lower-level execution primitives can silently circumvent established security controls, creating command execution and injection risks.
 **Prevention:** Consistently audit and refactor all command execution logic to route through centralized safe wrappers. Prohibit direct use of modules like `subprocess` or `os.system` via linting rules or code review policies.
+
+## 2025-02-23 - Replaced compile() with ast.parse() for Syntax Validation
+**Vulnerability:** Use of `compile(..., "exec")` in `workflows/generate_agent.py` to validate Python syntax of generated code.
+**Learning:** While `compile` is not as immediately dangerous as `exec()` or `eval()`, compiling untrusted or AI-generated code to executable bytecode presents potential denial of service (DoS) vectors (e.g. memory exhaustion, complex AST attacks) and flags SAST tools. `ast.parse` provides a safer mechanism to verify syntax without producing executable bytecode.
+**Prevention:** When validating Python syntax of untrusted code, always use `ast.parse(code)` instead of `compile(code, mode="exec")` to strictly limit the operation to syntax checking.

--- a/workflows/generate_agent.py
+++ b/workflows/generate_agent.py
@@ -5,6 +5,7 @@ This workflow generates new Review Agents for the Compounding Engineering
 based on natural language descriptions.
 """
 
+import ast
 import os
 from typing import Optional
 
@@ -108,7 +109,7 @@ def _verify_agent_code(spec_content: str) -> tuple[bool, str]:
 
     # Validate Python syntax
     try:
-        compile(cleaned, "<generated>", "exec")
+        ast.parse(cleaned)
     except SyntaxError as e:
         console.print(f"[red]Error: Generated code has syntax error: {e}[/red]")
         return False, cleaned


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of `compile(..., "exec")` in `workflows/generate_agent.py` to validate Python syntax of AI-generated code.
🎯 Impact: While `compile` is not `exec()` or `eval()`, compiling untrusted code to executable bytecode presents potential denial of service (DoS) vectors (e.g., memory exhaustion, complex AST attacks) and triggers static analysis (SAST) warnings.
🔧 Fix: Replaced `compile(cleaned, "<generated>", "exec")` with `ast.parse(cleaned)`. `ast.parse` provides a safer mechanism to verify syntax without producing executable bytecode.
✅ Verification: Ran `uv run pytest tests/` and verified that the change does not break syntax validation. Also added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9170783098688986592](https://jules.google.com/task/9170783098688986592) started by @Dan-StrategicAutomation*