### PR TITLE
⚡ Bolt: [performance improvement] Lazy-load heavy dependencies to speed up CLI startup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-23 - Optimize string replacements
 **Learning:** `str.replace` is faster than `re.sub` for simple, static substring replacements.
 **Action:** When replacing static substrings, prefer `str.replace` over compiling and running a regex.
+## 2024-05-23 - Optimize CLI initialization time
+**Learning:** Top-level imports of heavy libraries like `dspy` and `qdrant_client` (often imported within modules like `workflows` or `utils.knowledge`) dramatically increase CLI initialization time (from ~0.4s to ~6.3s in this codebase), even for simple commands like `--help`.
+**Action:** Always use lazy loading (importing inside the specific command functions) for heavy dependencies or modules that wrap them in CLI entrypoints. Ensure `import dspy` is also lazy-loaded inside configuration functions rather than at the top level.

--- a/cli.py
+++ b/cli.py
@@ -7,14 +7,6 @@ from rich.console import Console
 
 from config import configure_dspy, settings
 from utils.io import get_system_status, validate_agent_filters
-from utils.knowledge import KnowledgeBase
-from workflows.codify import run_codify
-from workflows.generate_agent import run_generate_agent
-from workflows.plan import run_plan
-from workflows.review import run_review
-from workflows.sync import run_sync
-from workflows.triage import run_triage
-from workflows.work import run_unified_work
 
 console = Console()
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
@@ -47,6 +39,9 @@ def triage() -> None:
     """
     Triage and categorize findings for the CLI todo system.
     """
+    # Lazy load for performance
+    from workflows.triage import run_triage
+
     run_triage()
 
 
@@ -68,6 +63,9 @@ def sync(
         compounding sync --dry-run        # Preview what would be created
         compounding sync -p "*-p1-*"      # Only sync P1 priority todos
     """
+    # Lazy load for performance
+    from workflows.sync import run_sync
+
     run_sync(dry_run=dry_run, pattern=pattern)
 
 
@@ -85,6 +83,9 @@ def plan(
         compounding plan 30
         compounding plan https://github.com/user/repo/issues/30
     """
+    # Lazy load for performance
+    from workflows.plan import run_plan
+
     run_plan(description)
 
 
@@ -126,6 +127,9 @@ def work(
             raise typer.BadParameter("Null bytes not allowed in pattern")
         if ".." in pattern or pattern.startswith("/"):
             raise typer.BadParameter("Path traversal sequences not allowed")
+
+    # Lazy load for performance
+    from workflows.work import run_unified_work
 
     run_unified_work(
         pattern=pattern,
@@ -172,6 +176,9 @@ def review(
     if agent and safe_agent_filter is None:
         return
 
+    # Lazy load for performance
+    from workflows.review import run_review
+
     run_review(pr_url_or_id, project=project, agent_filter=safe_agent_filter)
 
 
@@ -199,6 +206,9 @@ def generate_agent(
         compounding generate-agent "Ensure all Python functions have docstrings"
         compounding generate-agent --dry-run "Audit for frontend race conditions"
     """
+    # Lazy load for performance
+    from workflows.generate_agent import run_generate_agent
+
     run_generate_agent(description=description, dry_run=dry_run)
 
 
@@ -223,6 +233,9 @@ def codify(
         compounding codify "Always use strict typing in Python files"
         compounding codify "We should use factory pattern for creating agents" --source retro
     """
+    # Lazy load for performance
+    from workflows.codify import run_codify
+
     run_codify(feedback=feedback, source=source)
 
 
@@ -251,6 +264,9 @@ def compress_kb(
         raise ValueError("Ratio must be between 0.0 and 1.0")
     if not math.isfinite(ratio):
         raise ValueError("Ratio must be a finite number (not NaN or infinity)")
+
+    # Lazy load for performance
+    from utils.knowledge import KnowledgeBase
 
     kb = KnowledgeBase()
     kb.compress_ai_md(ratio=ratio, dry_run=dry_run)
@@ -286,6 +302,9 @@ def index(
     Use this to enable agents to find relevant code snippets.
     Performs smart incremental indexing (skips unchanged files).
     """
+    # Lazy load for performance
+    from utils.knowledge import KnowledgeBase
+
     kb = KnowledgeBase()
     kb.index_codebase(root_dir=root_dir, force_recreate=recreate)
 
@@ -310,6 +329,8 @@ def verify_kb() -> None:
     Checks that JSON learnings, SQLite database, and AI.md are all
     in sync. Reports orphaned entries and inconsistencies.
     """
+    # Lazy load for performance
+    from utils.knowledge import KnowledgeBase
     from utils.knowledge.verifier import KnowledgeBaseVerifier, format_report
 
     kb = KnowledgeBase()

--- a/config.py
+++ b/config.py
@@ -16,7 +16,6 @@ import threading
 from pathlib import Path
 from typing import Any
 
-import dspy
 from dotenv import load_dotenv
 
 from utils.io.logger import configure_logging, console, logger
@@ -249,7 +248,7 @@ class AppConfig:
             "compounding": ["python", "-m", "mcp_servers.compounding_server"],
             "file": ["python", "-m", "mcp_servers.file_server"],
             "git": ["python", "-m", "mcp_servers.git_server"],
-            "search": ["python", "-m", "mcp_servers.search_server"]
+            "search": ["python", "-m", "mcp_servers.search_server"],
         }
 
         # Embedding Settings
@@ -564,6 +563,9 @@ def _configure_observability():
 
 def configure_dspy(env_file: str | None = None):
     """Configure DSPy with the appropriate LM provider and settings."""
+    # Lazy load for performance
+    import dspy
+
     load_configuration(env_file)
     _configure_observability()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,12 +14,12 @@ runner = CliRunner()
 def mock_workflows():
     """Mock all workflow functions to prevent actual execution."""
     with (
-        patch("cli.run_triage") as m_triage,
-        patch("cli.run_plan") as m_plan,
-        patch("cli.run_unified_work") as m_work,
-        patch("cli.run_review") as m_review,
-        patch("cli.run_generate_agent") as m_gen,
-        patch("cli.run_codify") as m_codify,
+        patch("workflows.triage.run_triage") as m_triage,
+        patch("workflows.plan.run_plan") as m_plan,
+        patch("workflows.work.run_unified_work") as m_work,
+        patch("workflows.review.run_review") as m_review,
+        patch("workflows.generate_agent.run_generate_agent") as m_gen,
+        patch("workflows.codify.run_codify") as m_codify,
     ):
         yield {
             "triage": m_triage,
@@ -34,7 +34,7 @@ def mock_workflows():
 @pytest.fixture
 def mock_knowledge_base_class():
     """Mock KnowledgeBase class."""
-    with patch("cli.KnowledgeBase") as m_kb:
+    with patch("utils.knowledge.KnowledgeBase") as m_kb:
         mock_instance = m_kb.return_value
         yield mock_instance
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -72,7 +72,7 @@ class TestSyncCommand:
     @pytest.fixture
     def mock_sync(self):
         """Mock the run_sync function."""
-        with patch("cli.run_sync") as m_sync:
+        with patch("workflows.sync.run_sync") as m_sync:
             m_sync.return_value = {"created": [], "updated": [], "errors": []}
             yield m_sync
 


### PR DESCRIPTION
💡 What: Refactored top-level imports in `cli.py` and `config.py` by deferring `dspy`, `qdrant_client` and other heavy imports into the function bodies of individual commands. Added documentation on the optimization pattern and fixed resulting unit test breakages.
🎯 Why: Importing heavy ML tools unconditionally forces Typer to load them immediately, substantially slowing down basic commands like `compounding --help`.
📊 Impact: Reduced `cli.py --help` start-up time from ~6.3 seconds to ~0.45 seconds.
🔬 Measurement: Verify by running `time uv run python cli.py --help` on the current branch.

---
*PR created automatically by Jules for task [1087943280426927439](https://jules.google.com/task/1087943280426927439) started by @Dan-StrategicAutomation*