### PR TITLE
fix(security): replace compile() with ast.parse() for safer code validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Use of direct `subprocess.run` calls (e.g., in `workflows/review.py`) instead of the custom `run_safe_command` wrapper (`utils.io.safe`), bypassing the executable allowlist and `shell=True` prevention mechanisms.
 **Learning:** Security wrappers like `run_safe_command` are only effective if used universally. Direct use of lower-level execution primitives can silently circumvent established security controls, creating command execution and injection risks.
 **Prevention:** Consistently audit and refactor all command execution logic to route through centralized safe wrappers. Prohibit direct use of modules like `subprocess` or `os.system` via linting rules or code review policies.
+
+## 2025-02-24 - Validate Python Syntax with ast.parse instead of compile
+**Vulnerability:** Use of the `compile()` function in `workflows/generate_agent.py` to validate Python syntax on AI-generated untrusted code.
+**Learning:** `compile()` evaluates and generates executable bytecode, which can trigger static analysis security tool (SAST) warnings and poses a Denial of Service (DoS) risk if the code is deeply nested. It is unsafe for simple syntax validation.
+**Prevention:** Always use `ast.parse()` instead of `compile()`, `exec()`, or `eval()` to validate the syntax of untrusted or AI-generated Python code, ensuring no executable bytecode is created.

--- a/workflows/generate_agent.py
+++ b/workflows/generate_agent.py
@@ -5,6 +5,7 @@ This workflow generates new Review Agents for the Compounding Engineering
 based on natural language descriptions.
 """
 
+import ast
 import os
 from typing import Optional
 
@@ -108,7 +109,7 @@ def _verify_agent_code(spec_content: str) -> tuple[bool, str]:
 
     # Validate Python syntax
     try:
-        compile(cleaned, "<generated>", "exec")
+        ast.parse(cleaned)
     except SyntaxError as e:
         console.print(f"[red]Error: Generated code has syntax error: {e}[/red]")
         return False, cleaned


### PR DESCRIPTION
Replaced the use of `compile()` with `ast.parse()` in `workflows/generate_agent.py` when validating the syntax of AI-generated code. Since `compile()` generates executable bytecode, it poses a DoS risk for deeply nested code and triggers SAST tool warnings. `ast.parse()` is safer as it only validates syntax without bytecode generation.

Also updated `.jules/sentinel.md` with a journal entry documenting this security learning.

---
*PR created automatically by Jules for task [15475142234236091305](https://jules.google.com/task/15475142234236091305) started by @Dan-StrategicAutomation*