### PR TITLE
🎨 Palette: Enhance CLI UX with status spinners and info logs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2024-05-15 - Command output enhancement
 **Learning:** Found that CLI output via `SystemLogger.info` only prints to console if `to_cli=True`, otherwise it only logs to file. This makes some commands feel unresponsive, like it is hanging, to the user.
 **Action:** Enhance CLI UX by changing the rich console output using rich spinners for long operations.
+
+## 2026-06-04 - CLI Spinner UX
+**Learning:** Using `logger.status` for long-running blocking operations like fetching DB state provides crucial user feedback in this CLI app, preventing it from appearing unresponsive.
+**Action:** Use the `logger.status` context manager for any long database or network fetch tasks.

--- a/utils/knowledge/gardener.py
+++ b/utils/knowledge/gardener.py
@@ -342,7 +342,7 @@ class KnowledgeGardeningService:
             TextColumn,
         )
 
-        logger.info(f"Starting Hybrid Gardening (Deep Mode: {deep_mode})...")
+        logger.info(f"Starting Hybrid Gardening (Deep Mode: {deep_mode})...", to_cli=True)
         all_learnings = self.kb.get_all_learnings()
 
         stats = {"scored": 0, "deduped": 0, "extracted": 0, "skipped_extraction": 0}

--- a/utils/knowledge/indexer.py
+++ b/utils/knowledge/indexer.py
@@ -204,8 +204,8 @@ class CodebaseIndexer(CollectionManagerMixin):
             return
 
         # 2. Get current index state
-        logger.info("Fetching existing index state...")
-        indexed_files = self._get_indexed_files_metadata()
+        with logger.status("Fetching existing index state..."):
+            indexed_files = self._get_indexed_files_metadata()
 
         # 3. Process files
         updated_count = 0


### PR DESCRIPTION
💡 **What:** Added rich status spinners for long operations and made important start logs visible in the CLI.
🎯 **Why:** Previously, `logger.info` calls were silent in the terminal unless `to_cli=True` was explicitly set, making some long-running commands (like fetching DB state in `indexer.py` or initializing in `gardener.py`) seem unresponsive to the user.
📸 **Before/After:** The CLI will now show a nice spinner `⠋ Fetching existing index state...` instead of hanging silently.
♿ **Accessibility:** This improves overall usability and clarity for terminal users by giving them deterministic feedback that the process is running.

---
*PR created automatically by Jules for task [581622426920087642](https://jules.google.com/task/581622426920087642) started by @Dan-StrategicAutomation*