### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Argument Injection in Grep Search

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** Use of direct `subprocess.run` calls (e.g., in `workflows/review.py`) instead of the custom `run_safe_command` wrapper (`utils.io.safe`), bypassing the executable allowlist and `shell=True` prevention mechanisms.
 **Learning:** Security wrappers like `run_safe_command` are only effective if used universally. Direct use of lower-level execution primitives can silently circumvent established security controls, creating command execution and injection risks.
 **Prevention:** Consistently audit and refactor all command execution logic to route through centralized safe wrappers. Prohibit direct use of modules like `subprocess` or `os.system` via linting rules or code review policies.
+## 2026-06-05 - Fix Argument Injection in Grep Search
+**Vulnerability:** Command argument injection in `utils/io/files.py`'s search functionality, where untrusted queries could be interpreted as grep options (e.g. `--version`).
+**Learning:** Subprocess calls passing user input as positional arguments to utilities like `grep` or `git` are vulnerable to argument injection if the input starts with a hyphen.
+**Prevention:** Always use the `--` separator to signify the end of command-line options before passing untrusted positional arguments to shell utilities. For `grep`, explicitly use `-e` for the pattern as well.

--- a/utils/io/files.py
+++ b/utils/io/files.py
@@ -54,7 +54,9 @@ def _run_git_grep(query: str, safe_path: str, regex: bool, limit: int = 50) -> O
     git_cmd = ["git", "grep", "-n"]
     if not regex:
         git_cmd.append("-F")
+    git_cmd.append("-e")
     git_cmd.append(query)
+    git_cmd.append("--")
     git_cmd.append(".")
 
     try:
@@ -86,7 +88,9 @@ def _run_standard_grep(query: str, safe_path: str, regex: bool, limit: int = 50)
     for d in exclude_dirs:
         cmd.append(f"--exclude-dir={d}")
 
+    cmd.append("-e")
     cmd.append(query)
+    cmd.append("--")
     cmd.append(safe_path)
 
     process = run_safe_command(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command argument injection in `utils/io/files.py` search functionality, where untrusted queries could be interpreted as grep options (e.g. `--version`).
🎯 Impact: Attackers could inject arbitrary command options into `grep` or `git grep` processes if they can control the search query input.
🔧 Fix: Added `-e` to explicitly denote the query as a pattern, and the `--` separator to signify the end of command-line options before passing untrusted positional arguments.
✅ Verification: Ran `pytest` suite ensuring all tests pass with the modified logic.

---
*PR created automatically by Jules for task [12374325770268333175](https://jules.google.com/task/12374325770268333175) started by @Dan-StrategicAutomation*