### PR TITLE
🛡️ Sentinel: [HIGH] Fix command argument injection in grep

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Use of direct `subprocess.run` calls (e.g., in `workflows/review.py`) instead of the custom `run_safe_command` wrapper (`utils.io.safe`), bypassing the executable allowlist and `shell=True` prevention mechanisms.
 **Learning:** Security wrappers like `run_safe_command` are only effective if used universally. Direct use of lower-level execution primitives can silently circumvent established security controls, creating command execution and injection risks.
 **Prevention:** Consistently audit and refactor all command execution logic to route through centralized safe wrappers. Prohibit direct use of modules like `subprocess` or `os.system` via linting rules or code review policies.
+
+## 2025-02-24 - Prevent Command Argument Injection in Grep
+**Vulnerability:** Untrusted inputs (`query` and `safe_path`) were appended directly to `grep` and `git grep` command lists in `utils/io/files.py`. This allows argument/flag injection if an input starts with a hyphen (e.g., `--untracked`).
+**Learning:** Even when avoiding `shell=True` and using command lists, passing user input without explicit option terminators (`--`) or flags (like `-e` for grep patterns) can still result in command injection via flags.
+**Prevention:** Always use `--` to signify the end of command options before passing untrusted positional arguments to shell utilities. Use explicit flags (like `-e` for grep) for pattern arguments.

--- a/utils/io/files.py
+++ b/utils/io/files.py
@@ -54,7 +54,9 @@ def _run_git_grep(query: str, safe_path: str, regex: bool, limit: int = 50) -> O
     git_cmd = ["git", "grep", "-n"]
     if not regex:
         git_cmd.append("-F")
+    git_cmd.append("-e")
     git_cmd.append(query)
+    git_cmd.append("--")
     git_cmd.append(".")
 
     try:
@@ -86,7 +88,9 @@ def _run_standard_grep(query: str, safe_path: str, regex: bool, limit: int = 50)
     for d in exclude_dirs:
         cmd.append(f"--exclude-dir={d}")
 
+    cmd.append("-e")
     cmd.append(query)
+    cmd.append("--")
     cmd.append(safe_path)
 
     process = run_safe_command(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential argument/flag injection in grep commands due to unprotected positional arguments.
🎯 Impact: Attackers could inject flags (like `--exec`, `--invert-match`, etc.) into git/standard grep if they control the query or path inputs.
🔧 Fix: Appended `-e` for patterns and `--` before positional arguments to secure command lists.
✅ Verification: Ensure tests pass and standard search functionality handles inputs starting with hyphens as literal strings.

---
*PR created automatically by Jules for task [2883871884113833195](https://jules.google.com/task/2883871884113833195) started by @Dan-StrategicAutomation*