### PR TITLE
Refactor workflow signatures to typed Pydantic outputs

### DIFF
--- a/agents/schema/__init__.py
+++ b/agents/schema/__init__.py
@@ -1,4 +1,10 @@
-from .base import BaseResearchReport, ResearchInsight
+from .base import (
+    BaseResearchReport,
+    MarkdownCompressionRequest,
+    MarkdownCompressionResult,
+    ResearchInsight,
+    WorkflowResult,
+)
 from .research import (
     BestPracticesReport,
     FrameworkDocsReport,
@@ -6,16 +12,29 @@ from .research import (
     RepoResearchReport,
 )
 from .review import ReviewFinding, ReviewReport
-from .workflow import PlanReport
+from .workflow import (
+    GeneratedAgentSpec,
+    PlanExecutionResult,
+    PlanReport,
+    TodoResolutionResult,
+    TriagePresentation,
+)
 
 __all__ = [
     "BaseResearchReport",
+    "MarkdownCompressionRequest",
+    "MarkdownCompressionResult",
     "ResearchInsight",
+    "WorkflowResult",
     "BestPracticesReport",
     "FrameworkDocsReport",
     "GitHistoryReport",
     "RepoResearchReport",
     "ReviewFinding",
     "ReviewReport",
+    "GeneratedAgentSpec",
+    "PlanExecutionResult",
     "PlanReport",
+    "TodoResolutionResult",
+    "TriagePresentation",
 ]

--- a/agents/schema/base.py
+++ b/agents/schema/base.py
@@ -3,6 +3,23 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 
+class WorkflowResult(BaseModel):
+    """Base class for structured workflow result models."""
+
+
+class MarkdownCompressionRequest(BaseModel):
+    """Structured input for markdown compression requests."""
+
+    content: str = Field(..., description="The markdown content to compress")
+    ratio: float = Field(..., description="Target compression ratio from 0.0 to 1.0")
+
+
+class MarkdownCompressionResult(BaseModel):
+    """Structured output for markdown compression results."""
+
+    compressed_content: str = Field(..., description="The compressed markdown content")
+
+
 class ResearchInsight(BaseModel):
     """Standardized model for a single research discovery or insight."""
 

--- a/agents/schema/workflow.py
+++ b/agents/schema/workflow.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import Dict, List, Optional
 
 from pydantic import Field
 
-from agents.schema.base import BaseResearchReport
+from agents.schema.base import BaseResearchReport, WorkflowResult
 
 
 class PlanReport(BaseResearchReport):
@@ -19,4 +19,68 @@ class PlanReport(BaseResearchReport):
     )
     implementation_steps: List[str] = Field(
         default_factory=list, description="Step-by-step tasks for implementation"
+    )
+
+
+class PlanExecutionResult(WorkflowResult):
+    """Structured result returned after executing a plan."""
+
+    execution_summary: str = Field(
+        ..., description="What was accomplished while executing the plan"
+    )
+    files_modified: List[str] = Field(
+        default_factory=list, description="List of files changed during plan execution"
+    )
+    reasoning_trace: str = Field(..., description="Step-by-step ReAct reasoning process")
+    verification_status: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Verification results for each modified file. Key=filename, Value=status",
+    )
+    success_status: bool = Field(..., description="Whether plan execution was successful")
+
+
+class TodoResolutionResult(WorkflowResult):
+    """Structured result returned after resolving a todo."""
+
+    resolution_summary: str = Field(
+        ..., description="What was accomplished while resolving the todo"
+    )
+    files_modified: List[str] = Field(
+        default_factory=list, description="List of files changed during todo resolution"
+    )
+    reasoning_trace: str = Field(..., description="Step-by-step ReAct reasoning process")
+    verification_status: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Verification results for each modified file. Key=filename, Value=status",
+    )
+    success_status: bool = Field(..., description="Whether todo resolution was successful")
+
+
+class TriagePresentation(WorkflowResult):
+    """Structured presentation and decision for a triaged finding."""
+
+    formatted_presentation: str = Field(..., description="The formatted presentation for triage")
+    proposed_solution: str = Field(
+        ..., description="The specific proposed solution or recommended action to be taken"
+    )
+    action_required: bool = Field(
+        ...,
+        description="False if no code changes are needed; True if action or changes are required",
+    )
+
+
+class GeneratedAgentSpec(WorkflowResult):
+    """Structured specification for a generated review agent file."""
+
+    file_name: str = Field(..., description="Snake-case file name, e.g. sql_injection_reviewer.py")
+    class_name: str = Field(..., description="CamelCase class name, e.g. SqlInjectionReviewer")
+    agent_name: str = Field(
+        ..., description="Hyphenated agent name for CLI use, e.g. SQL-Injection-Reviewer"
+    )
+    applicable_languages: Optional[List[str]] = Field(
+        None, description="List of languages this agent applies to, or None for all languages"
+    )
+    code_content: str = Field(
+        ...,
+        description="Full Python file content including imports and dspy.Signature class",
     )

--- a/agents/workflow/agent_generator.py
+++ b/agents/workflow/agent_generator.py
@@ -1,19 +1,6 @@
-from typing import List, Optional
-
 import dspy
-from pydantic import BaseModel, Field
 
-
-class AgentFileSpec(BaseModel):
-    file_name: str = Field(..., description="Target file name (e.g. 'security_scanner.py')")
-    class_name: str = Field(..., description="Target class name (e.g. 'SecurityScanner')")
-    agent_name: str = Field(..., description="Human-readable agent name")
-    applicable_languages: Optional[List[str]] = Field(
-        None, description="List of languages this agent applies to, or None for all"
-    )
-    code_content: str = Field(
-        ..., description="Full Python file content including imports and signature"
-    )
+from agents.schema.workflow import GeneratedAgentSpec
 
 
 class AgentGenerator(dspy.Signature):
@@ -92,15 +79,6 @@ class AgentGenerator(dspy.Signature):
         desc="Comma-separated list of valid categories. __agent_category__ MUST be one of these."
     )
 
-    file_name: str = dspy.OutputField(desc="Snake-case file name (e.g. sql_injection_reviewer.py)")
-    class_name: str = dspy.OutputField(desc="CamelCase class name (e.g. SqlInjectionReviewer)")
-    agent_name: str = dspy.OutputField(
-        desc="Hyphenated name for CLI (e.g. SQL-Injection-Reviewer). NO SPACES - use hyphens!"
-    )
-    applicable_languages: List[str] = dspy.OutputField(
-        desc="List of languages this agent applies to (e.g. ['python', 'javascript'])"
-    )
-    code_content = dspy.OutputField(
-        desc="Full Python file content. MUST include: dspy.Signature class, "
-        "review_report output field using dspy.OutputField, and proper imports."
+    generated_agent: GeneratedAgentSpec = dspy.OutputField(
+        desc="Structured generated agent file specification and complete Python code content"
     )

--- a/agents/workflow/triage_agent.py
+++ b/agents/workflow/triage_agent.py
@@ -1,5 +1,7 @@
 import dspy
 
+from agents.schema.workflow import TriagePresentation
+
 
 class TriageAgent(dspy.Signature):
     """
@@ -56,11 +58,6 @@ class TriageAgent(dspy.Signature):
     """
 
     finding_content: str = dspy.InputField(desc="The raw content of the finding or todo")
-    formatted_presentation: str = dspy.OutputField(desc="The formatted presentation for triage")
-    proposed_solution: str = dspy.OutputField(
-        desc="The specific proposed solution or recommended action to be taken"
-    )
-    action_required: bool = dspy.OutputField(
-        desc="False if no code changes needed (review passed, no issues), "
-        "True if action/changes required"
+    triage_presentation: TriagePresentation = dspy.OutputField(
+        desc="Structured triage presentation, proposed solution, and action-required decision"
     )

--- a/agents/workflow/work_plan_executor.py
+++ b/agents/workflow/work_plan_executor.py
@@ -1,5 +1,6 @@
 import dspy
 
+from agents.schema.workflow import PlanExecutionResult
 from config import settings
 from utils.agent.tools import get_todo_resolver_tools
 
@@ -59,13 +60,12 @@ class PlanExecutionSignature(dspy.Signature):
     plan_content: str = dspy.InputField(desc="Content of the plan file")
     plan_path: str = dspy.InputField(desc="Path to the plan file")
 
-    execution_summary: str = dspy.OutputField(desc="What was accomplished")
-    files_modified: list[str] = dspy.OutputField(desc="List of files that were changed")
-    reasoning_trace: str = dspy.OutputField(desc="Step-by-step ReAct reasoning process")
-    verification_status: dict[str, str] = dspy.OutputField(
-        desc="Verification results for each modified file. Key=filename, Value=status"
+    execution_result: PlanExecutionResult = dspy.OutputField(
+        desc=(
+            "Structured result containing summary, modified files, reasoning, "
+            "verification, and success"
+        )
     )
-    success_status: bool = dspy.OutputField(desc="Whether execution was successful")
 
 
 class ReActPlanExecutor(dspy.Module):

--- a/agents/workflow/work_todo_executor.py
+++ b/agents/workflow/work_todo_executor.py
@@ -1,5 +1,6 @@
 import dspy
 
+from agents.schema.workflow import TodoResolutionResult
 from config import settings
 from utils.agent.tools import get_todo_resolver_tools
 
@@ -76,13 +77,12 @@ class TodoResolutionSignature(dspy.Signature):
     todo_content: str = dspy.InputField(desc="Content of the todo file")
     todo_id: str = dspy.InputField(desc="Unique identifier of the todo")
 
-    resolution_summary: str = dspy.OutputField(desc="What was accomplished")
-    files_modified: list[str] = dspy.OutputField(desc="List of files that were changed")
-    reasoning_trace: str = dspy.OutputField(desc="Step-by-step ReAct reasoning process")
-    verification_status: dict[str, str] = dspy.OutputField(
-        desc="Verification results for each modified file. Key=filename, Value=status"
+    resolution_result: TodoResolutionResult = dspy.OutputField(
+        desc=(
+            "Structured result containing summary, modified files, reasoning, "
+            "verification, and success"
+        )
     )
-    success_status: bool = dspy.OutputField(desc="Whether resolution was successful")
 
 
 class ReActTodoResolver(dspy.Module):

--- a/tests/test_workflow_signature_models.py
+++ b/tests/test_workflow_signature_models.py
@@ -1,0 +1,111 @@
+from pydantic import BaseModel
+
+from agents.schema.base import MarkdownCompressionRequest, MarkdownCompressionResult
+from agents.schema.workflow import (
+    GeneratedAgentSpec,
+    PlanExecutionResult,
+    TodoResolutionResult,
+    TriagePresentation,
+)
+from agents.workflow.agent_generator import AgentGenerator
+from agents.workflow.triage_agent import TriageAgent
+from agents.workflow.work_plan_executor import PlanExecutionSignature
+from agents.workflow.work_todo_executor import TodoResolutionSignature
+from utils.knowledge.compression import CompressMarkdown
+
+
+def _field_annotation(signature_cls, field_name):
+    return signature_cls.fields[field_name].annotation
+
+
+def _output_field_names(signature_cls):
+    return set(signature_cls.output_fields)
+
+
+def test_plan_execution_signature_uses_single_structured_result():
+    assert _output_field_names(PlanExecutionSignature) == {"execution_result"}
+    assert _field_annotation(PlanExecutionSignature, "execution_result") is PlanExecutionResult
+    assert issubclass(PlanExecutionResult, BaseModel)
+
+    result = PlanExecutionResult(
+        execution_summary="Updated plan implementation.",
+        files_modified=["workflows/work.py"],
+        reasoning_trace="Read, edited, verified.",
+        verification_status={"workflows/work.py": "passed"},
+        success_status=True,
+    )
+
+    assert result.execution_summary == "Updated plan implementation."
+    assert result.files_modified == ["workflows/work.py"]
+    assert result.verification_status["workflows/work.py"] == "passed"
+    assert result.success_status is True
+
+
+def test_todo_resolution_signature_uses_single_structured_result():
+    assert _output_field_names(TodoResolutionSignature) == {"resolution_result"}
+    assert _field_annotation(TodoResolutionSignature, "resolution_result") is TodoResolutionResult
+    assert issubclass(TodoResolutionResult, BaseModel)
+
+    result = TodoResolutionResult(
+        resolution_summary="Resolved todo.",
+        files_modified=["agents/workflow/work_todo_executor.py"],
+        reasoning_trace="Inspected and verified todo resolution.",
+        verification_status={"agents/workflow/work_todo_executor.py": "passed"},
+        success_status=True,
+    )
+
+    assert result.resolution_summary == "Resolved todo."
+    assert result.files_modified == ["agents/workflow/work_todo_executor.py"]
+    assert result.success_status is True
+
+
+def test_triage_agent_signature_uses_single_structured_presentation():
+    assert _output_field_names(TriageAgent) == {"triage_presentation"}
+    assert _field_annotation(TriageAgent, "triage_presentation") is TriagePresentation
+    assert issubclass(TriagePresentation, BaseModel)
+
+    presentation = TriagePresentation(
+        formatted_presentation="Issue #1: No action required",
+        proposed_solution="Close as already passing.",
+        action_required=False,
+    )
+
+    assert presentation.formatted_presentation.startswith("Issue #1")
+    assert presentation.proposed_solution == "Close as already passing."
+    assert presentation.action_required is False
+
+
+def test_agent_generator_signature_uses_single_generated_agent_spec():
+    assert _output_field_names(AgentGenerator) == {"generated_agent"}
+    assert _field_annotation(AgentGenerator, "generated_agent") is GeneratedAgentSpec
+    assert issubclass(GeneratedAgentSpec, BaseModel)
+
+    spec = GeneratedAgentSpec(
+        file_name="example_reviewer.py",
+        class_name="ExampleReviewer",
+        agent_name="Example-Reviewer",
+        applicable_languages=["python"],
+        code_content="import dspy\n",
+    )
+
+    assert spec.file_name == "example_reviewer.py"
+    assert spec.class_name == "ExampleReviewer"
+    assert spec.agent_name == "Example-Reviewer"
+    assert spec.applicable_languages == ["python"]
+    assert spec.code_content == "import dspy\n"
+
+
+def test_compress_markdown_signature_uses_structured_models():
+    assert set(CompressMarkdown.input_fields) == {"compression_request"}
+    assert _output_field_names(CompressMarkdown) == {"compression_result"}
+    assert _field_annotation(CompressMarkdown, "compression_request") is MarkdownCompressionRequest
+    assert _field_annotation(CompressMarkdown, "compression_result") is MarkdownCompressionResult
+    assert issubclass(MarkdownCompressionRequest, BaseModel)
+    assert issubclass(MarkdownCompressionResult, BaseModel)
+
+    request = MarkdownCompressionRequest(content="# Title\n\nDetails", ratio=0.5)
+    result = MarkdownCompressionResult(compressed_content="# Title\n\nShort details")
+
+    assert request.content == "# Title\n\nDetails"
+    assert request.ratio == 0.5
+    assert result.compressed_content == "# Title\n\nShort details"

--- a/utils/knowledge/compression.py
+++ b/utils/knowledge/compression.py
@@ -1,8 +1,11 @@
+import json
 import logging
 import os
 from typing import List
 
 import dspy
+
+from agents.schema.base import MarkdownCompressionRequest, MarkdownCompressionResult
 
 
 class CompressMarkdown(dspy.Signature):
@@ -13,9 +16,12 @@ class CompressMarkdown(dspy.Signature):
     Retain all headers, code blocks, and list structures where possible.
     """
 
-    content: str = dspy.InputField(desc="The markdown content to compress")
-    ratio: float = dspy.InputField(desc="Target compression ratio (0.0 to 1.0)")
-    compressed_content: str = dspy.OutputField(desc="The compressed markdown content")
+    compression_request: MarkdownCompressionRequest = dspy.InputField(
+        desc="Structured markdown content and target compression ratio"
+    )
+    compression_result: MarkdownCompressionResult = dspy.OutputField(
+        desc="Structured compressed markdown content"
+    )
 
 
 class LLMKBCompressor(dspy.Module):
@@ -52,8 +58,6 @@ class LLMKBCompressor(dspy.Module):
         cache_path = self._get_cache_path()
         if os.path.exists(cache_path):
             try:
-                import json
-
                 with open(cache_path, "r") as f:
                     return json.load(f)
             except Exception:
@@ -64,13 +68,11 @@ class LLMKBCompressor(dspy.Module):
         cache_path = self._get_cache_path()
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         try:
-            import json
-
             with open(cache_path, "w") as f:
                 json.dump(cache, f, indent=2)
         except Exception:
             # Cache write failures are non-fatal; log and continue.
-            logging.debug("Failed to save LLM compression cache to %s", cache_path, exc_info=True)
+            logging.debug(f"Failed to save LLM compression cache to {cache_path}", exc_info=True)
 
     def forward(self, content: str, ratio: float = 0.5) -> str:
         """
@@ -88,7 +90,9 @@ class LLMKBCompressor(dspy.Module):
 
         # Use split-compress-merge strategy
         if len(content) < 4000:
-            result = self.compressor(content=content, ratio=ratio).compressed_content
+            result = self.compressor(
+                compression_request=MarkdownCompressionRequest(content=content, ratio=ratio)
+            ).compression_result.compressed_content
         else:
             chunks = self._split_markdown_by_headers(content)
             compressed_chunks = []
@@ -99,8 +103,10 @@ class LLMKBCompressor(dspy.Module):
                     continue
 
                 try:
-                    res = self.compressor(content=chunk, ratio=ratio)
-                    compressed_chunks.append(res.compressed_content)
+                    res = self.compressor(
+                        compression_request=MarkdownCompressionRequest(content=chunk, ratio=ratio)
+                    )
+                    compressed_chunks.append(res.compression_result.compressed_content)
                 except Exception as e:
                     logging.warning(f"Compression failed for chunk: {e}")
                     compressed_chunks.append(chunk)

--- a/workflows/generate_agent.py
+++ b/workflows/generate_agent.py
@@ -200,16 +200,7 @@ def run_generate_agent(description: str, dry_run: bool = False):
             valid_categories=valid_categories,
         )
 
-        # Reconstruct Spec object from individual fields
-        from agents.workflow.agent_generator import AgentFileSpec
-
-        spec = AgentFileSpec(
-            file_name=result.file_name,
-            class_name=result.class_name,
-            agent_name=result.agent_name,
-            applicable_languages=result.applicable_languages,
-            code_content=result.code_content,
-        )
+        spec = result.generated_agent
 
         if not spec.code_content:
             console.print("[red]Agent failed to return valid agent code.[/red]")

--- a/workflows/triage.py
+++ b/workflows/triage.py
@@ -121,21 +121,19 @@ def run_triage():  # noqa: C901
         # Use LLM to present the finding
         with logger.status("Analyzing finding..."):
             response = triage_predictor(finding_content=content)
+        triage_presentation = response.triage_presentation
 
-        console.print(Markdown(response.formatted_presentation))
+        console.print(Markdown(triage_presentation.formatted_presentation))
         console.print("\n")
 
         # Debug: Show action_required value
-        if hasattr(response, "action_required"):
-            if response.action_required:
-                action_status = "⚠️  Action IS Required (code changes needed)"
-            else:
-                action_status = "✅ No Action Required (review passed)"
-            console.print(f"[dim]Analysis: {action_status}[/dim]")
+        if triage_presentation.action_required:
+            action_status = "⚠️  Action IS Required (code changes needed)"
         else:
-            console.print("[dim yellow]Warning: action_required field not present[/dim yellow]")
+            action_status = "✅ No Action Required (review passed)"
+        console.print(f"[dim]Analysis: {action_status}[/dim]")
 
-        should_auto_complete = hasattr(response, "action_required") and not response.action_required
+        should_auto_complete = not triage_presentation.action_required
         if should_auto_complete:
             console.print("[dim]🤖 Auto-completing: No action required[/dim]")
 
@@ -172,9 +170,7 @@ def run_triage():  # noqa: C901
                 new_content = content.replace("status: pending", "status: ready")
 
                 # Fill recommended action with the proposed solution from triage
-                solution = (
-                    response.proposed_solution if hasattr(response, "proposed_solution") else None
-                )
+                solution = triage_presentation.proposed_solution
                 new_content = _fill_recommended_action(new_content, solution)
 
                 new_content = add_work_log_entry(
@@ -237,11 +233,7 @@ def run_triage():  # noqa: C901
                     new_content = remaining_content.replace("status: pending", "status: ready")
 
                     # Fill recommended action with proposed solution if available
-                    solution = (
-                        response.proposed_solution
-                        if hasattr(response, "proposed_solution")
-                        else None
-                    )
+                    solution = triage_presentation.proposed_solution
                     new_content = _fill_recommended_action(new_content, solution)
 
                     new_content = add_work_log_entry(
@@ -291,9 +283,7 @@ def run_triage():  # noqa: C901
                 new_content = re.sub(r"priority: p[123]", f"priority: {new_priority}", new_content)
 
                 # Fill recommended action with proposed solution
-                solution = (
-                    response.proposed_solution if hasattr(response, "proposed_solution") else None
-                )
+                solution = triage_presentation.proposed_solution
                 new_content = _fill_recommended_action(new_content, solution)
 
                 new_content = add_work_log_entry(

--- a/workflows/work.py
+++ b/workflows/work.py
@@ -155,11 +155,12 @@ def _run_react_todo(  # noqa: C901
             # Use ReAct resolver
             resolver = ReActTodoResolver(base_dir=worktree_path or ".")
             result = resolver(todo_content=todo["content"], todo_id=todo["id"])
+            resolution_result = result.resolution_result
 
             # Mark complete using service
             complete_todo(
                 todo["path"],
-                resolution_summary=getattr(result, "resolution_summary", "Resolved via ReAct"),
+                resolution_summary=resolution_result.resolution_summary,
                 action_msg="Resolved via ReAct Agent",
             )
 
@@ -170,17 +171,17 @@ def _run_react_todo(  # noqa: C901
                 codify_work_outcome(
                     todo_id=todo["id"],
                     todo_slug=todo["slug"],
-                    resolution_summary=getattr(result, "resolution_summary", "Resolved via ReAct"),
-                    operations_count=len(getattr(result, "files_modified", [])),
-                    success=getattr(result, "success_status", False),
+                    resolution_summary=resolution_result.resolution_summary,
+                    operations_count=len(resolution_result.files_modified),
+                    success=resolution_result.success_status,
                 )
             except Exception:
                 pass  # Don't fail resolution if codification fails
 
             return {
-                "status": "success" if getattr(result, "success_status", False) else "error",
+                "status": "success" if resolution_result.success_status else "error",
                 "todo_id": todo["id"],
-                "summary": getattr(result, "resolution_summary", str(result)),
+                "summary": resolution_result.resolution_summary,
             }
         except Exception as e:
             return {"status": "error", "todo_id": todo["id"], "error": str(e)}
@@ -316,10 +317,12 @@ def _run_react_plan(plan_path: str, dry_run: bool, in_place: bool = True):
 
         result = executor(plan_content=content, plan_path=plan_path)
 
-        if result.success_status:
-            console.print(f"[green]Success:[/green] {result.execution_summary}")
+        execution_result = result.execution_result
+
+        if execution_result.success_status:
+            console.print(f"[green]Success:[/green] {execution_result.execution_summary}")
         else:
-            console.print(f"[red]Failed:[/red] {result.execution_summary}")
+            console.print(f"[red]Failed:[/red] {execution_result.execution_summary}")
 
     except Exception as e:
         console.print(f"[red]Error executing plan: {e}[/red]")


### PR DESCRIPTION
### Motivation
- Consolidate multiple raw DSPy output fields into single, typed Pydantic result models to improve schema clarity and DSPy introspection for workflow agents and tools.
- Make compression inputs/outputs structured so KB compression and callers use explicit models instead of loosely-typed primitives.

### Description
- Added shared workflow schemas in `agents/schema/base.py`: `WorkflowResult`, `MarkdownCompressionRequest`, and `MarkdownCompressionResult`.
- Added typed workflow result models in `agents/schema/workflow.py`: `PlanExecutionResult`, `TodoResolutionResult`, `TriagePresentation`, and `GeneratedAgentSpec`, and exported them via `agents/schema/__init__.py`.
- Replaced multi-field outputs on signatures with single nested model outputs in `agents/workflow/work_plan_executor.py`, `agents/workflow/work_todo_executor.py`, `agents/workflow/triage_agent.py`, and `agents/workflow/agent_generator.py` (now use `execution_result`, `resolution_result`, `triage_presentation`, and `generated_agent`).
- Wrapped KB compression signature in `utils/knowledge/compression.py` to accept `MarkdownCompressionRequest` and return `MarkdownCompressionResult`, and updated call sites and callers in workflows to read nested model attributes.
- Added `tests/test_workflow_signature_models.py` asserting the modified signatures use the new structured Pydantic models and that the models behave as expected.

### Testing
- Ran `python -m compileall` on the touched modules which succeeded and confirmed there are no syntax errors in the modified files.
- Ran `ruff check` for the modified files (`agents/schema/base.py`, `agents/schema/workflow.py`, `agents/schema/__init__.py`, `agents/workflow/*`, `utils/knowledge/compression.py`, `workflows/*`, and the new test) and fixed line-length/formatting issues; those checks for the changed files passed.
- Added unit tests in `tests/test_workflow_signature_models.py` and compiled them, but full `pytest` could not be executed in this environment due to missing project dependencies (e.g., `pydantic`) and network failures when attempting dependency installation.
- Note: a repository-wide lint run flagged pre-existing issues outside the touched files; the changes in this PR are self-consistent and lint-clean after targeted fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cfb0d88b8833388a9f31d0fed91b9)